### PR TITLE
Make symbolator_sphinx work with newer sphinx verions

### DIFF
--- a/symbolator_sphinx/symbolator_sphinx.py
+++ b/symbolator_sphinx/symbolator_sphinx.py
@@ -15,6 +15,7 @@
 import re
 import codecs
 import posixpath
+from errno import ENOENT, EPIPE, EINVAL
 from os import path
 from subprocess import Popen, PIPE
 from hashlib import sha1
@@ -30,7 +31,7 @@ from sphinx.errors import SphinxError
 from sphinx.locale import _, __
 from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
-from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
+from sphinx.util.osutil import ensuredir
 
 if False:
     # For type annotation


### PR DESCRIPTION
symbolator_sphinx is broken for sphinx>3.5.4 due to the imports of `ENOENT, EPIPE, EINVAL`.

This PR imports these from the "official" errno module in python stdlib instead.

Tested locally on Ubuntu 18.04 with python 3.9.9 and sphinx 4.3.2.